### PR TITLE
Add CI task

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -12,6 +12,8 @@ To install Ruby CSS Lint, Add it to your gemfile
 And after a bundle install, run it:
   rake css_lint:run
 
+To run on a CI system, and have the task return a failing exit code with any problems:
+  rake css_lint:ci
 
 You probably want more control over things, so generate a config file:
   rake css_lint:generate_config

--- a/lib/ruby_css_lint.rb
+++ b/lib/ruby_css_lint.rb
@@ -12,6 +12,10 @@ if defined?(Rails)
             RubyCssLint::construct_js_and_run_rhino(RubyCssLint::location_of_css_files(Rails.root))
           end
 
+          task :ci => :environment do |t|
+            fail if RubyCssLint::construct_js_and_run_rhino(RubyCssLint::location_of_css_files(Rails.root)) > 0
+          end
+
           task :dump_to_file => :environment do |t|
             RubyCssLint::construct_js_and_run_rhino(RubyCssLint::location_of_css_files(Rails.root), 'css_lint_output.txt')
           end
@@ -114,7 +118,7 @@ HEADER
 FOOTER
       tempfile.puts`cat #{list_of_js_files_to_compile_step_2}`
       tempfile.flush
-      run_rhino_with_js_file(tempfile.path, css_files, output_location)
+      return run_rhino_with_js_file(tempfile.path, css_files, output_location)
     end
 
     
@@ -126,6 +130,7 @@ FOOTER
     command += " > #{output_location}" if output_location
     result = `#{command}`
     puts result
+    return $?.exitstatus
   end
   
   def self.list_of_js_files_to_compile_step_1


### PR DESCRIPTION
Add a new ci task to fail if any problems are found from csslint.  This helps support CI system that rely on exit codes to fail.